### PR TITLE
feature: create admin config as secret

### DIFF
--- a/pkg/controller/managedpki_controller.go
+++ b/pkg/controller/managedpki_controller.go
@@ -26,7 +26,10 @@ import (
 	"github.com/patrostkowski/controlplane-operator/pkg/controlplane/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -107,6 +110,12 @@ func (r *ManagedPKIReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// We wait for certManger resources ensured
+	// so it shouldn't fail
+	if err := r.ensureAdminConfig(ctx, req.Namespace); err != nil {
+		return ctrl.Result{}, nil
+	}
+
 	log.Info("Finished reconciling ManagedPKI")
 
 	return ctrl.Result{}, nil
@@ -117,7 +126,6 @@ func (r *ManagedPKIReconciler) ensureResources(
 	pkiObj *mcpv1alpha1.ManagedPKI,
 	resources []client.Object,
 ) error {
-
 	for _, desired := range resources {
 		r.Log.Info("Ensuring PKI resource", "name", desired.GetName(), "namespace", desired.GetNamespace(), "kind", desired.GetObjectKind())
 
@@ -143,7 +151,6 @@ func (r *ManagedPKIReconciler) checkResourcesReady(
 	ctx context.Context,
 	resources []client.Object,
 ) (bool, error) {
-
 	allReady := true
 
 	for _, desired := range resources {
@@ -180,6 +187,59 @@ func (r *ManagedPKIReconciler) checkResourcesReady(
 	}
 
 	return allReady, nil
+}
+
+// Still it doesnt look perfect
+func (r *ManagedPKIReconciler) ensureAdminConfig(ctx context.Context, ns string) error {
+	// hardcoded until we find a way to pass
+	// API server addr
+	serverURL := "https://172.30.0.250:6443"
+	// get admin-client secret
+	adminClient := &corev1.Secret{}
+	if err := r.Get(ctx, client.ObjectKey{Name: "admin-client", Namespace: ns}, adminClient); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	ca := adminClient.Data["ca.crt"]
+	crt := adminClient.Data["tls.crt"]
+	key := adminClient.Data["tls.key"]
+
+	// build kubecfg
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters["local"] = &clientcmdapi.Cluster{
+		Server:                   serverURL,
+		CertificateAuthorityData: ca,
+	}
+	cfg.AuthInfos["local"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: crt,
+		ClientKeyData:         key,
+	}
+	cfg.Contexts["local"] = &clientcmdapi.Context{Cluster: "local", AuthInfo: "local"}
+	cfg.CurrentContext = "local"
+
+	kubeconfigBytes, err := clientcmd.Write(*cfg)
+	if err != nil {
+		return err
+	}
+
+	s := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "admin-config",
+			Namespace: ns,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"config": kubeconfigBytes},
+	}
+
+	if err := r.Patch(ctx, s, client.Apply, client.FieldOwner("managedpki-controller")); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *ManagedPKIReconciler) isIssuerReady(iss *certmanagerv1.Issuer) bool {

--- a/pkg/controlplane/pki/pki.go
+++ b/pkg/controlplane/pki/pki.go
@@ -20,10 +20,7 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	mcpv1alpha1 "github.com/patrostkowski/controlplane-operator/pkg/apis/controlplane.patrostkowski.dev/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -336,8 +333,6 @@ func Resources(pkiObj *mcpv1alpha1.ManagedPKI) []client.Object {
 		objs = append(objs, BuildCertificate(cs))
 	}
 
-	objs = append(objs, BuildConfigMap(pkiObj))
-
 	return objs
 }
 
@@ -414,53 +409,4 @@ func BuildCertificate(spec PKICertificateSpec) *certmanagerv1.Certificate {
 
 	c.Spec = certSpec
 	return c
-}
-
-func BuildConfigMap(pki *mcpv1alpha1.ManagedPKI) *corev1.ConfigMap {
-	ns := pki.Namespace
-
-	kcfg := BuildAdminKubeconfig(ns)
-
-	kubeconfigData, err := clientcmd.Write(*kcfg)
-	if err != nil {
-		panic(err) // should never happen
-	}
-
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "admin-kubeconfig",
-			Namespace: ns,
-		},
-		Data: map[string]string{
-			"config": string(kubeconfigData),
-		},
-	}
-}
-
-func BuildAdminKubeconfig(namespace string) *clientcmdapi.Config {
-	serverURL := "https://kube-apiserver." + namespace + ".svc:6443"
-
-	cfg := clientcmdapi.NewConfig()
-
-	// --- Cluster ---
-	cfg.Clusters["local"] = &clientcmdapi.Cluster{
-		Server:                   serverURL,
-		CertificateAuthorityData: []byte{},
-	}
-
-	// --- User ---
-	cfg.AuthInfos["local"] = &clientcmdapi.AuthInfo{
-		ClientCertificateData: []byte{},
-		ClientKeyData:         []byte{},
-	}
-
-	// --- Context ---
-	cfg.Contexts["local"] = &clientcmdapi.Context{
-		Cluster:  "local",
-		AuthInfo: "local",
-	}
-
-	cfg.CurrentContext = "local"
-
-	return cfg
 }


### PR DESCRIPTION
As we rely on `cert manager`  to generate admin tls data - its pointless to create empty secret from there.
We wait for all `PKI` resources and create admin config from reconcile instead.

Example:
```bash
# Get admin config from secret
➜  controlplane-operator git:(feat/create-admin-secret) ✗ kubectl get secret -n mcp admin-config \
  -o jsonpath='{.data.config}' | base64 -d > cfg
# Get cluster info
➜  controlplane-operator git:(feat/create-admin-secret) ✗ k cluster-info --kubeconfig=cfg
Kubernetes control plane is running at https://kube-apiserver.mcp.svc:6443
# Deploy pod and see if it deployed on managed cluster
➜  controlplane-operator git:(feat/create-admin-secret) ✗ k run nginx --image=nginx -n default --kubeconfig=cfg
pod/nginx created

(⎈|kind-kind:default)
➜  controlplane-operator git:(feat/create-admin-secret) ✗ k get all -A --kubeconfig=cfg
NAMESPACE   NAME        READY   STATUS    RESTARTS   AGE
default     pod/nginx   0/1     Pending   0          3s

NAMESPACE   NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
default     service/kubernetes   ClusterIP   10.200.0.1   <none>        443/TCP   25m
```